### PR TITLE
Push notifications via PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Built in all-Javascript MERN stack - MongoDB, Express, React, and Node.js. Also 
 
 [Local certificate setup](https://web.dev/articles/how-to-use-local-https)
 
-To run just the frontend over HTTPS, run web's `npm run start:ssl`
+To run just the frontend over HTTPS, run `cd web && npm run start:ssl`
 
 > Access it at https://localhost:3000/
 
-To run the whole app over HTTPS, build the stack and then run api's `npm run start:ssl`
+To run the whole app over HTTPS, build the stack and then run `cd api && npm run start:ssl`
 
 > Access it at https://localhost:5001/
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1574,6 +1574,15 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/web-push": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.3.tgz",
+      "integrity": "sha512-v3oT4mMJsHeJ/rraliZ+7TbZtr5bQQuxcgD7C3/1q/zkAj29c8RE0F9lVZVu3hiQe5Z9fYcBreV7TLnfKR+4mg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -2051,6 +2060,17 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -2176,6 +2196,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
     "body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -2296,6 +2321,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
       "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -2860,6 +2890,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3949,6 +3987,14 @@
         }
       }
     },
+    "http_ece": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.1.0.tgz",
+      "integrity": "sha512-bptAfCDdPJxOs5zYSe7Y3lpr772s1G346R4Td5LgRUeCwIGpCGDUTJxRrhTNcAXbx37spge0kWEIH7QAYWNTlA==",
+      "requires": {
+        "urlsafe-base64": "~1.0.0"
+      }
+    },
     "https-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -4957,6 +5003,25 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -5216,6 +5281,11 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5223,6 +5293,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minipass": {
       "version": "5.0.0",
@@ -6926,6 +7001,11 @@
         "requires-port": "^1.0.0"
       }
     },
+    "urlsafe-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
+      "integrity": "sha512-RtuPeMy7c1UrHwproMZN9gN6kiZ0SvJwRaEzwZY0j9MypEkFqyBaKv176jvlPtg58Zh36bOkS0NFABXMHvvGCA=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6991,6 +7071,50 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "web-push": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.6.tgz",
+      "integrity": "sha512-SyteEck9fiCskNmPxs/GFhJsZrIyLfRvjWNmcUwULLJyCU0f1oxo2sWTokXA1mDAq9vxk4e4gVcb/8agq73NkQ==",
+      "requires": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.1.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "webidl-conversions": {

--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,7 @@
     "rimraf": "^3.0.2",
     "spotify-web-api-node": "^5.0.0",
     "ts-node": "^8.6.1",
+    "web-push": "^3.6.6",
     "winston": "^3.3.3"
   },
   "devDependencies": {
@@ -64,6 +65,7 @@
     "@types/lodash": "^4.14.149",
     "@types/mongodb": "^3.3.16",
     "@types/rimraf": "^3.0.0",
+    "@types/web-push": "^3.6.3",
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
     "eslint": "^8.3.0",

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -2,5 +2,6 @@ export * from './log-controller';
 export * from './login-controller';
 export * from './playlists-controller';
 export * from './search-controller';
+export * from './subscription-controller';
 export * from './track-controller';
 export * from './user-controller';

--- a/api/src/controllers/subscription-controller.ts
+++ b/api/src/controllers/subscription-controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Post } from '@overnightjs/core';
+import { Request, Response } from 'express';
+
+import { saveSubscription } from '../services/subscription-service';
+
+@Controller('subscription')
+export class SubscriptionController {
+    @Post('')
+    async saveSubscription(req: Request, res: Response) {
+        await saveSubscription(req.body);
+
+        res.sendStatus(200);
+    }
+}

--- a/api/src/core/session/models/user.ts
+++ b/api/src/core/session/models/user.ts
@@ -12,4 +12,5 @@ export interface User extends DBObject {
 
     // Feature flags
     suppressNewCacheFeature: boolean;
+    enableNotificationFeature: boolean;
 }

--- a/api/src/core/shared-models/index.ts
+++ b/api/src/core/shared-models/index.ts
@@ -3,4 +3,5 @@ export * from './artist';
 export * from './cache';
 export * from './db';
 export * from './requests';
+export * from './subscription';
 export * from './util';

--- a/api/src/core/shared-models/subscription.ts
+++ b/api/src/core/shared-models/subscription.ts
@@ -1,0 +1,8 @@
+import { ObjectId } from 'mongodb';
+import { PushSubscription } from 'web-push';
+
+import { SimpleDBObject } from '../../../../shared';
+
+export interface Subscription extends PushSubscription, SimpleDBObject {
+    userId: ObjectId;
+}

--- a/api/src/core/test-data/index.ts
+++ b/api/src/core/test-data/index.ts
@@ -3,6 +3,7 @@ import { albumContainsRuleFactory, artistContainsRuleFactory, artistIsRuleFactor
 import { trackFactory } from './track-factory';
 
 export * from './spotify-api-type-factory';
+export * from './subscription-factory';
 export {
     albumContainsRuleFactory,
     artistContainsRuleFactory,

--- a/api/src/core/test-data/subscription-factory.ts
+++ b/api/src/core/test-data/subscription-factory.ts
@@ -1,0 +1,22 @@
+import * as Factory from 'factory.ts';
+import moment from 'moment';
+import { ObjectId } from 'mongodb';
+
+import { Subscription } from '../shared-models';
+
+import randomStringFactory from './random-string-factory';
+
+
+export const subscriptionFactory = Factory.Sync.makeFactory<Subscription>({
+    id: Factory.each(() => randomStringFactory(22)),
+    createdAt: moment().toDate(),
+    updatedAt: moment().toDate(),
+
+    endpoint: `https://fcm.googleapis.com/fcm/send/${randomStringFactory(152)}`,
+    keys: {
+        p256dh: randomStringFactory(87),
+        auth: randomStringFactory(22),
+    },
+
+    userId: Factory.each(() => new ObjectId()),
+});

--- a/api/src/core/test-data/user-factory.ts
+++ b/api/src/core/test-data/user-factory.ts
@@ -18,4 +18,5 @@ export const userFactory = Factory.Sync.makeFactory<User>({
     refreshToken: 'testRefreshToken',
 
     suppressNewCacheFeature: false,
+    enableNotificationFeature: false,
 });

--- a/api/src/repositories/subscription-repository.ts
+++ b/api/src/repositories/subscription-repository.ts
@@ -1,0 +1,14 @@
+import { ObjectID } from 'mongodb';
+import { MongoRepository } from 'mongtype';
+import { PushSubscription } from 'web-push';
+
+import dbc from './dbc';
+
+
+interface Subscription extends PushSubscription {
+    userId: ObjectID;
+}
+
+const subscriptionRepo = new MongoRepository<Subscription>(dbc, { name: 'subscriptions' });
+
+export default subscriptionRepo;

--- a/api/src/repositories/subscription-repository.ts
+++ b/api/src/repositories/subscription-repository.ts
@@ -1,13 +1,9 @@
-import { ObjectID } from 'mongodb';
 import { MongoRepository } from 'mongtype';
-import { PushSubscription } from 'web-push';
+
+import { Subscription } from '../core/shared-models';
 
 import dbc from './dbc';
 
-
-interface Subscription extends PushSubscription {
-    userId: ObjectID;
-}
 
 const subscriptionRepo = new MongoRepository<Subscription>(dbc, { name: 'subscriptions' });
 

--- a/api/src/services/playlist-service/pre-validate-publish-playlist.test.ts
+++ b/api/src/services/playlist-service/pre-validate-publish-playlist.test.ts
@@ -9,6 +9,7 @@ import updatePlaylist from './update-playlist';
 
 jest.mock('../spotify-service/spotify-service');
 jest.mock('../cache/spotify/spotify-cache-service');
+jest.mock('../subscription-service');
 jest.mock('../user-service');
 jest.mock('./publish-playlist');
 jest.mock('./update-playlist');

--- a/api/src/services/playlist-service/pre-validate-publish-playlist.ts
+++ b/api/src/services/playlist-service/pre-validate-publish-playlist.ts
@@ -5,6 +5,7 @@ import logger from '../../core/logger/logger';
 import spotifyService from '../spotify-service/spotify-service';
 
 import publishPlaylist from './publish-playlist';
+import sendPlaylistDeletedNotification from './send-playlist-deleted-notification';
 import updatePlaylist from './update-playlist';
 
 
@@ -23,6 +24,7 @@ async function preValidatePublishPlaylist(playlist: Playlist, accessToken: strin
         // User has deleted playlist since last publish
         if (!userHasPlaylist) {
             await updatePlaylist(playlist.id, { deleted: true });
+            sendPlaylistDeletedNotification(playlist.userId, playlist.name);
             return;
         }
     }

--- a/api/src/services/playlist-service/send-playlist-deleted-notification.ts
+++ b/api/src/services/playlist-service/send-playlist-deleted-notification.ts
@@ -1,0 +1,13 @@
+import { ObjectID } from 'mongodb';
+
+import { sendNotification } from '../subscription-service';
+
+function sendPlaylistDeletedNotification(userId: ObjectID, playlistName: string) {
+    sendNotification({
+        userId,
+        title: 'Playlist deleted from Spotify',
+        body: `The smart playlist ${playlistName} was deleted from Spotify. If this was an accident, click Publish to restore it.`,
+    });
+}
+
+export default sendPlaylistDeletedNotification;

--- a/api/src/services/subscription-service/index.ts
+++ b/api/src/services/subscription-service/index.ts
@@ -1,0 +1,7 @@
+import saveSubscription from './save-subscription';
+import sendNotification from './send-notification';
+
+export {
+    saveSubscription,
+    sendNotification,
+};

--- a/api/src/services/subscription-service/save-subscription.ts
+++ b/api/src/services/subscription-service/save-subscription.ts
@@ -1,0 +1,17 @@
+import subscriptionRepo from '../../repositories/subscription-repository';
+
+import { getCurrentUser } from '../user-service';
+
+
+async function saveSubscription(subscriptionValue) {
+    const user = await getCurrentUser();
+    const subscription = {
+        ...subscriptionValue,
+        userId: user.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    };
+    return subscriptionRepo.create(subscription);
+}
+
+export default saveSubscription;

--- a/api/src/services/subscription-service/send-notification.test.ts
+++ b/api/src/services/subscription-service/send-notification.test.ts
@@ -1,0 +1,42 @@
+import { ObjectId } from 'mongodb';
+import webpush from 'web-push';
+
+import { subscriptionFactory } from '../../core/test-data';
+
+import subscriptionRepo from '../../repositories/subscription-repository';
+
+import sendNotification from './send-notification';
+
+
+jest.mock('web-push');
+
+const mockedFind = jest.mocked(subscriptionRepo.find);
+
+describe('sendNotification', () => {
+    it('should send notification for every subscription of that user', async () => {
+        // Arrange
+        const userId = new ObjectId();
+        const expectedNotificationTitle = 'Some title';
+        const expectedNotificationBody = 'Some notification body';
+        const numSubscriptions = 3;
+        const userSubscriptions = subscriptionFactory.buildList(numSubscriptions);
+        mockedFind.mockResolvedValue(userSubscriptions);
+
+        // Act
+        await sendNotification({
+            userId,
+            title: expectedNotificationTitle,
+            body: expectedNotificationBody,
+        });
+
+        // Assert
+        const expectedString = JSON.stringify({
+            notification: {
+                title: expectedNotificationTitle,
+                body: expectedNotificationBody,
+            },
+        });
+        expect(webpush.sendNotification).toHaveBeenCalledTimes(numSubscriptions);
+        expect(webpush.sendNotification).toHaveBeenCalledWith(userSubscriptions[0], expectedString);
+    });
+});

--- a/api/src/services/subscription-service/send-notification.test.ts
+++ b/api/src/services/subscription-service/send-notification.test.ts
@@ -1,20 +1,30 @@
 import { ObjectId } from 'mongodb';
 import webpush from 'web-push';
 
-import { subscriptionFactory } from '../../core/test-data';
+import { subscriptionFactory, userFactory } from '../../core/test-data';
 
 import subscriptionRepo from '../../repositories/subscription-repository';
+
+import { getUserById } from '../user-service';
 
 import sendNotification from './send-notification';
 
 
 jest.mock('web-push');
+jest.mock('../user-service/get-user-by-id');
 
 const mockedFind = jest.mocked(subscriptionRepo.find);
+const mockedGetUserById = jest.mocked(getUserById);
 
 describe('sendNotification', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('should send notification for every subscription of that user', async () => {
         // Arrange
+        // Feature flag enableNotificationFeature -- code line can be removed after go-live
+        mockedGetUserById.mockResolvedValue(userFactory.build({ enableNotificationFeature: true }));
         const userId = new ObjectId();
         const expectedNotificationTitle = 'Some title';
         const expectedNotificationBody = 'Some notification body';

--- a/api/src/services/subscription-service/send-notification.ts
+++ b/api/src/services/subscription-service/send-notification.ts
@@ -1,0 +1,53 @@
+import { ObjectID, ObjectId } from 'mongodb';
+import webpush from 'web-push';
+
+import subscriptionRepo from '../../repositories/subscription-repository';
+
+
+interface NotificationData {
+    title: string;
+    body: string;
+    image?: string;
+}
+
+interface NotificationPayload {
+    notification: NotificationData;
+}
+
+const vapidKeys = {
+    publicKey: process.env.VAPID_PUBLIC_KEY || 'BEPu-gOV_yG6r3CA730UXi4X8Md6IFbPUG-mZX9hVMXj_nmyUoO91_VRBYSoOKLgYYZYJ1HQ578MRgxMCwxXK1Y',
+    privateKey: process.env.VAPID_PRIVATE_KEY,
+};
+
+if (!vapidKeys.publicKey || !vapidKeys.privateKey) {
+    console.warn('You must set VAPID keys to use Push Notifications');
+} else {
+    webpush.setVapidDetails(
+        'mailto:smartlistmusic@gmail.com',
+        vapidKeys.publicKey,
+        vapidKeys.privateKey,
+    );
+}
+
+async function sendNotification({
+    userId,
+    title,
+    body,
+}: {
+    userId: string|ObjectID,
+    title: string,
+    body: string,
+}) {
+    const subscriptions = await subscriptionRepo.find({
+        conditions: { userId: new ObjectId(userId).toString() },
+    });
+    if (!subscriptions.length) {
+        console.debug(`No subscriptions found for userId = ${userId}`);
+        return;
+    }
+    const notification: NotificationData = { title, body };
+    const notificationData: NotificationPayload = { notification };
+    subscriptions.map((subscription) => webpush.sendNotification(subscription, JSON.stringify(notificationData)));
+}
+
+export default sendNotification;

--- a/api/src/services/subscription-service/send-notification.ts
+++ b/api/src/services/subscription-service/send-notification.ts
@@ -3,6 +3,8 @@ import webpush from 'web-push';
 
 import subscriptionRepo from '../../repositories/subscription-repository';
 
+import { getUserById } from '../user-service';
+
 
 interface NotificationData {
     title: string;
@@ -38,6 +40,13 @@ async function sendNotification({
     title: string,
     body: string,
 }) {
+    // Feature flag enableNotificationFeature -- code block can be removed after go-live
+    const user = await getUserById(userId);
+    if (!user.enableNotificationFeature) {
+        console.debug(`Feature flag enableNotificationFeature is not enabled for userId = ${userId}`);
+        return;
+    }
+
     const subscriptions = await subscriptionRepo.find({
         conditions: { userId: new ObjectId(userId).toString() },
     });

--- a/web/config-overrides.js
+++ b/web/config-overrides.js
@@ -1,4 +1,6 @@
-const { babelInclude, override, removeModuleScopePlugin, addWebpackPlugin, addWebpackResolve } = require('customize-cra');
+const {
+    babelInclude, override, removeModuleScopePlugin, addWebpackPlugin, addWebpackResolve,
+} = require('customize-cra');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 const path = require('path');
 const { GenerateSW } = require('workbox-webpack-plugin');
@@ -20,6 +22,9 @@ module.exports = override(
             new GenerateSW({
                 skipWaiting: true,
                 clientsClaim: true,
+                importScripts: [
+                    'sw-handle-push.js',
+                ],
             }),
         ) : null,
 );

--- a/web/public/sw-handle-push.js
+++ b/web/public/sw-handle-push.js
@@ -1,0 +1,14 @@
+
+
+self.addEventListener('push', function(e) {
+    const dataObj = e.data.json();
+
+    const notificationData = dataObj.notification;
+    const notificationTitle = notificationData.title;
+    const notificationOptions = {
+        body: notificationData.body,
+        icon: notificationData.image || 'favicon.ico',
+    };
+
+    e.waitUntil(self.registration.showNotification(notificationTitle, notificationOptions));
+});

--- a/web/src/playlists/use-fetch-playlists.tsx
+++ b/web/src/playlists/use-fetch-playlists.tsx
@@ -4,6 +4,8 @@ import { Playlist } from '../../../shared';
 
 import { baseRequestUrl, requests } from '../core/requests/requests';
 
+import setupSubscription from '../service-worker/setup-subscription';
+
 
 export const getPlaylistsQueryKey = () => ['playlists'];
 
@@ -12,6 +14,12 @@ export const useFetchPlaylists = () => {
         queryKey: getPlaylistsQueryKey(),
         queryFn: async () => {
             return await requests.get(`${baseRequestUrl}/playlists/lists`);
+        },
+        onSuccess: (data) => {
+            if (data.length === 0) {
+                return;
+            }
+            setupSubscription();
         },
         staleTime: (60 * 60 * 1000),
         refetchOnWindowFocus: false,

--- a/web/src/service-worker/setup-subscription.ts
+++ b/web/src/service-worker/setup-subscription.ts
@@ -1,0 +1,63 @@
+import { baseRequestUrl, requests } from '../core/requests/requests';
+
+
+const publicVapidKey = process.env.VAPID_PUBLIC_KEY || 'BEPu-gOV_yG6r3CA730UXi4X8Md6IFbPUG-mZX9hVMXj_nmyUoO91_VRBYSoOKLgYYZYJ1HQ578MRgxMCwxXK1Y';
+
+function urlBase64ToUint8Array(base64String) {
+    const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding)
+        .replace(/-/g, '+')
+        .replace(/_/g, '/');
+
+    const rawData = window.atob(base64);
+    const outputArray = new Uint8Array(rawData.length);
+
+    for (let i = 0; i < rawData.length; ++i) {
+        outputArray[i] = rawData.charCodeAt(i);
+    }
+    return outputArray;
+}
+
+function sendSubscriptionToServer(subscription: PushSubscription) {
+    return requests.post(`${baseRequestUrl}/subscription`, subscription);
+}
+
+async function subscribeToPush(swReg: ServiceWorkerRegistration) {
+    const subscription = await swReg.pushManager.subscribe({
+        applicationServerKey: urlBase64ToUint8Array(publicVapidKey),
+        userVisibleOnly: true,
+    });
+    sendSubscriptionToServer(subscription);
+}
+
+async function setupSubscription() {
+    const swReg = await navigator.serviceWorker.ready;
+
+    if (!('showNotification' in swReg)) {
+        console.warn('Notifications aren\'t supported.');
+        return;
+    }
+    if (Notification.permission === 'denied') {
+        console.warn('The user has blocked notifications.');
+        return;
+    }
+    if (!('PushManager' in window)) {
+        console.warn('Push messaging isn\'t supported.');
+        return;
+    }
+
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') {
+        console.warn('The user has not granted notifications.');
+        return;
+    }
+
+    const subscription = await swReg.pushManager.getSubscription();
+
+    if (!subscription){
+        console.log('No Subscription endpoint present');
+        subscribeToPush(swReg);
+    }
+}
+
+export default setupSubscription;


### PR DESCRIPTION
The housekeeping needed to make PWA notifications work:
- Install web-push (server side)
- Add repo `subscriptions` to store client/server subscriptions in DB
- When user sufficiently engaged with app, then create a subscription (via Push Manager) and send to server to save in DB
  - Permissions check for notifications happen automatically at this time
- When server finds a reason to notify user (i.e., a playlist was deleted from Spotify), then send a notification to user, via all subscriptions found in DB matching that user
- Service worker code handles notification sent to client, shows notification via Notification API

New notifications to be sent out:
- When playlist found to be deleted from Spotify

User-facing functionality is behind a feature flag `enableNotificationFeature` for now.

